### PR TITLE
Upgraded to version 2.49.0

### DIFF
--- a/IEDriverServer.nuspec
+++ b/IEDriverServer.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>IEDriverServer</id>
     <title>IEDriverServer</title>
-    <version>2.32.3</version>
+    <version>2.49.0</version>
     <authors>Chromium and WebDriver teams</authors>
     <owners>Yann ROBIN</owners>
     <summary>The InternetExplorerDriver is a standalone server which implements WebDriver's wire protocol</summary>

--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -1,8 +1,8 @@
 ﻿#NOTE: Please remove any commented lines to tidy up prior to releasing the package, including this one
 
 $packageName = 'IEDriverServer' # arbitrary name for the package, used in messages
-$url = 'https://selenium.googlecode.com/files/IEDriverServer_Win32_2.32.3.zip' # download url
-$url64 = 'https://selenium.googlecode.com/files/IEDriverServer_x64_2.32.3.zip' # 64bit URL here or just use the same as $url
+$url = 'http://selenium-release.storage.googleapis.com/2.49/IEDriverServer_Win32_2.49.0.zip' # download url
+$url64 = 'http://selenium-release.storage.googleapis.com/2.49/IEDriverServer_x64_2.49.0.zip' # 64bit URL here or just use the same as $url
 $validExitCodes = @(0) #please insert other valid exit codes here, exit codes for ms http://msdn.microsoft.com/en-us/library/aa368542(VS.85).aspx
 
 # download and unpack a zip file


### PR DESCRIPTION
Hi, I have found out that the package points to quite an old release of IEDriverServer. I have adjusted it to point to the most current version 2.49.0.
I'd be really glad if you could update it on Chocolatey feed. Thank you.
